### PR TITLE
fix: 修复Socket Family属性的返回值显示不正确问题

### DIFF
--- a/harmony/tcp_socket/src/main/ets/TcpEventListener.ts
+++ b/harmony/tcp_socket/src/main/ets/TcpEventListener.ts
@@ -13,7 +13,7 @@ export class TcpEventListener {
   async onConnection(serverId: number, clientId: number, connection: socket.TCPSocketConnection) {
     let localAddress = await connection?.getLocalAddress() as socket.NetAddress;
     let remoteAddress = await connection?.getRemoteAddress() as socket.NetAddress;
-    let localFamily = remoteAddress.family === 1 ? "IPv6" : "IPv4"
+    let localFamily = remoteAddress.family === 2 ? "IPv6" : "IPv4"
     this.sendEvent("connection", {
       "id": serverId,
       "info": {
@@ -32,7 +32,7 @@ export class TcpEventListener {
   async onSecureConnection(serverId: number, clientId: number, connection: socket.TLSSocketConnection) {
     let localAddress = await connection?.getLocalAddress() as socket.NetAddress;
     let remoteAddress = await connection?.getRemoteAddress() as socket.NetAddress;
-    let remoteFamily = remoteAddress.family === 1 ? "IPv6" : "IPv4"
+    let remoteFamily = remoteAddress.family === 2 ? "IPv6" : "IPv4"
     this.sendEvent("secureConnection", {
       "id": serverId,
       "info": {
@@ -54,6 +54,7 @@ export class TcpEventListener {
       client.getSocket();
     let localAddress = await tcpSocket?.getLocalAddress() as socket.NetAddress;
     let remoteAddress = await tcpSocket?.getRemoteAddress() as socket.NetAddress;
+    let remoteFamily = remoteAddress.family === 2 ? "IPv6" : "IPv4"
     this.sendEvent("connect", {
       "id": cid,
       "connection": {
@@ -61,7 +62,7 @@ export class TcpEventListener {
         "localPort": localAddress.port,
         "remoteAddress": remoteAddress.address,
         "remotePort": remoteAddress.port,
-        "remoteFamily": remoteAddress.family
+        "remoteFamily": remoteFamily
       }
     });
   }
@@ -69,7 +70,7 @@ export class TcpEventListener {
   async onListen(cId: number, tcpSocketServer: TcpSocketServer) {
     let serverSocket: socket.TCPSocketServer | socket.TLSSocketServer = tcpSocketServer.getServerSocket();
     let address: socket.NetAddress = await serverSocket.getLocalAddress();
-    let localFamily = address.family === 1 ? "IPv6" : "IPv4"
+    let localFamily = address.family === 2 ? "IPv6" : "IPv4"
     this.sendEvent("listening", {
       "id": cId,
       "connection": {


### PR DESCRIPTION
# Summary

修复Socket Family属性的返回值显示不正确问题

Closes #7 
## Test Plan
修改之后，Socket Family的返回值应该为‘ipv4’或者‘ipv6'

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

