### PR TITLE
fix: 修复Server close之后连接未正常关闭，且一个server多次close报错问题

### DIFF
--- a/harmony/tcp_socket/src/main/ets/TcpSocketServer.ts
+++ b/harmony/tcp_socket/src/main/ets/TcpSocketServer.ts
@@ -141,8 +141,6 @@ export class TcpSocketServer extends TcpSocket {
   close() {
     this.tcpSocketServer?.off("connect");
     this.tlsSocketServer?.off("connect");
-    this.tcpSocketServer = undefined;
-    this.tlsSocketServer = undefined;
     this.receiverListener?.onClose(this.getId(), null);
   }
 }

--- a/harmony/tcp_socket/src/main/ets/TcpSocketTurboModule.ts
+++ b/harmony/tcp_socket/src/main/ets/TcpSocketTurboModule.ts
@@ -140,9 +140,10 @@ export class TcpSocketTurboModule extends TurboModule implements TM.TcpSocketMod
 
   close(cid: number): void {
     let socketServer: TcpSocketServer = this.getTcpServer(cid);
-    socketServer.close();
+    socketServer?.close();
+    let socketClient: TcpSocketClient = this.getTcpClient(cid);
+    socketClient?.destroy();
     this.socketMap.delete(cid);
-
   }
 
   destroy(cid: number): void {


### PR DESCRIPTION

# Summary

修复Server close之后连接未正常关闭，且一个server多次close报错问题

Closes #10 

## Test Plan

测试close方法之后，再次close 无报错

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
